### PR TITLE
Update versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
         "php": ">=5.5.9",
         "symfony/symfony":"~2.7|~3.0",
         "sensio/framework-extra-bundle": "~2.7|~3.0",
-        "php-http/httplug": "1.0.0-beta",
+        "php-http/httplug": "~1.0",
         "php-http/discovery": "^0.4|^0.5",
-        "php-http/plugins": "dev-master",
+        "php-http/plugins": "~1.0",
         "php-http/client-implementation": "1.0",
         "psr/log": "1.0.0"
     },


### PR DESCRIPTION
Hi,

Version at tag 0.2.2 use unstable versions of php-http/httplug and php-http/plugins.
I just switched to stable versions to allow installation of your translationBundle in projects with default minimum-stability :)

And thx for this bundle, really useful !