### PR TITLE
Handle not existing translation file

### DIFF
--- a/src/Translation/FilesystemUpdater.php
+++ b/src/Translation/FilesystemUpdater.php
@@ -5,6 +5,7 @@ namespace Happyr\TranslationBundle\Translation;
 use Happyr\TranslationBundle\Model\Message;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\Translation\Dumper\DumperInterface;
+use Symfony\Component\Translation\Exception\NotFoundResourceException;
 use Symfony\Component\Translation\Loader\LoaderInterface;
 use Symfony\Component\Translation\MessageCatalogue;
 
@@ -110,7 +111,12 @@ class FilesystemUpdater
             $key = $m->getLocale().$m->getDomain();
             if (!isset($catalogues[$key])) {
                 $file = sprintf('%s/%s.%s.%s', $this->targetDir, $m->getDomain(), $m->getLocale(), $this->getFileExtension());
-                $catalogues[$key] = $this->loader->load($file, $m->getLocale(), $m->getDomain());
+                
+                try {
+                    $catalogues[$key] = $this->loader->load($file, $m->getLocale(), $m->getDomain());
+                } catch (NotFoundResourceException $e) {
+                    $catalogues[$key] = new MessageCatalogue($m->getLocale());
+                }
             }
 
             $translation = $m->getTranslation();


### PR DESCRIPTION
I do not commit my translations files, and running `app/console happyr:translation:sync` on an empty translations directory is killing the command:

```
[Symfony\Component\Translation\Exception\NotFoundResourceException]                                  
  File "/home/dalexandre/Dev/pony-are-like-unicorn/app/Resources/translations/messages.fr.xlf" not found.
```

This PR allow the translation file to be created if it does not exists :+1: 