### PR TITLE
Handle hierarchy parent in flattening Loco resp

### DIFF
--- a/src/Service/Loco.php
+++ b/src/Service/Loco.php
@@ -333,7 +333,11 @@ class Loco implements TranslationServiceInterface
                     unset($messages[$key]);
                 }
             } elseif (null !== $path) {
-                $messages[$path.'.'.$key] = $value;
+                if ($key !== 0) {
+                    $messages[$path.'.'.$key] = $value;
+                } else {
+                    $messages[$path] = $value;
+                }
             }
         }
     }


### PR DESCRIPTION
When having keys like this:

```
navigation.dropdown.rent
navigation.dropdown.rent.service
navigation.dropdown.rent.luxury
```

Loco return a response like this:

![image](https://cloud.githubusercontent.com/assets/225704/13606899/284c8978-e54e-11e5-88b8-96e71d18aa36.png)

One of the keys is zero, and my translation file is populated with `navigation.dropdown.rent.0`.

This PR fix this issue.