### PR TITLE
Allow to not sync empty translations

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -23,6 +23,7 @@ class Configuration implements ConfigurationInterface
             ->scalarNode('target_dir')->defaultValue('%kernel.root_dir%/Resources/translations')->end()
             ->scalarNode('httplug_client')->defaultValue('httplug.client')->cannotBeEmpty()->end()
             ->scalarNode('httplug_message_factory')->defaultValue('httplug.message_factory')->cannotBeEmpty()->end()
+            ->booleanNode('sync_empty_translations')->defaultTrue()->end()
             ->booleanNode('auto_add_assets')->defaultFalse()->end()
             ->booleanNode('allow_edit')->defaultTrue()->end()
             ->enumNode('file_extension')->values(array('csv', 'ini', 'json', 'mo', 'php', 'po', 'qt', 'yaml', 'xlf'))->defaultValue('xlf')->end()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -26,7 +26,7 @@ class Configuration implements ConfigurationInterface
             ->booleanNode('sync_empty_translations')->defaultTrue()->end()
             ->booleanNode('auto_add_assets')->defaultFalse()->end()
             ->booleanNode('allow_edit')->defaultTrue()->end()
-            ->enumNode('file_extension')->values(array('csv', 'ini', 'json', 'mo', 'php', 'po', 'qt', 'yaml', 'xlf'))->defaultValue('xlf')->end()
+            ->enumNode('file_extension')->values(array('csv', 'ini', 'json', 'mo', 'php', 'po', 'qt', 'yml', 'xlf'))->defaultValue('xlf')->end()
             ->arrayNode('locales')
                 ->requiresAtLeastOneElement()
                 ->prototype('scalar')->end()

--- a/src/DependencyInjection/HappyrTranslationExtension.php
+++ b/src/DependencyInjection/HappyrTranslationExtension.php
@@ -33,7 +33,8 @@ class HappyrTranslationExtension extends Extension
         $targetDir = rtrim($config['target_dir'], '/');
         $container->findDefinition('happyr.translation.filesystem')
             ->replaceArgument(2, $targetDir)
-            ->replaceArgument(3, $config['file_extension']);
+            ->replaceArgument(3, $config['file_extension'])
+            ->replaceArgument(4, $config['sync_empty_translations']);
 
         $this->configureLoaderAndDumper($container, $config['file_extension']);
 

--- a/src/DependencyInjection/HappyrTranslationExtension.php
+++ b/src/DependencyInjection/HappyrTranslationExtension.php
@@ -76,8 +76,13 @@ class HappyrTranslationExtension extends Extension
      */
     protected function configureLoaderAndDumper(ContainerBuilder $container, $fileExtension)
     {
-        if ($fileExtension === 'xlf') {
-            $fileExtension = 'xliff';
+        switch ($fileExtension) {
+            case 'xlf':
+                $fileExtension = 'xliff';
+                break;
+            case 'yml':
+                $fileExtension = 'yaml';
+                break;
         }
 
         $loader = $container->register('happyr.translation.loader', sprintf('Symfony\Component\Translation\Loader\%sFileLoader', ucfirst($fileExtension)));

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -30,6 +30,7 @@ services:
       - '@happyr.translation.dumper'
       - ~
       - ~
+      - ~
     tags:
       - { name: kernel.event_listener, event: kernel.terminate, method: onTerminate, priority: -20 }
       - { name: kernel.event_listener, event: console.terminate, method: onTerminate, priority: -20 }

--- a/src/Translation/FilesystemUpdater.php
+++ b/src/Translation/FilesystemUpdater.php
@@ -42,20 +42,27 @@ class FilesystemUpdater
     private $messages;
 
     /**
+     * @var bool
+     */
+    private $syncEmptyTranslations;
+
+    /**
      * Filesystem constructor.
      *
      * @param LoaderInterface $loader
      * @param DumperInterface $dumper
-     * @param                 $targetDir
-     * @param                 $fileExtension
+     * @param string          $targetDir
+     * @param string          $fileExtension
+     * @param bool            $syncEmptyTranslations
      */
-    public function __construct(LoaderInterface $loader, DumperInterface $dumper, $targetDir, $fileExtension)
+    public function __construct(LoaderInterface $loader, DumperInterface $dumper, $targetDir, $fileExtension, $syncEmptyTranslations = true)
     {
         $this->loader = $loader;
         $this->dumper = $dumper;
         $this->targetDir = $targetDir;
         $this->messages = array();
         $this->fileExtension = $fileExtension;
+        $this->syncEmptyTranslations = $syncEmptyTranslations;
     }
 
     /**
@@ -121,7 +128,11 @@ class FilesystemUpdater
 
             $translation = $m->getTranslation();
             if (empty($translation)) {
-                $translation = sprintf('[%s]', $m->getId());
+                if ($this->syncEmptyTranslations) {
+                    $translation = sprintf('[%s]', $m->getId());
+                } else {
+                    continue;
+                }
             }
 
             $catalogues[$key]->set($m->getId(), $translation, $m->getDomain());


### PR DESCRIPTION
Usually empty messages should not be written to the filesystem otherwise the symfony translator fallback cannot do it's job.
For not breaking current behaviour, it's possible to configure this option and the default will be true (write empty messages to filesystem).
In a major update of this bundle, the default could be set to false.