### PR TITLE
Feature/guzzle http factory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     },
     "suggest": {
         "php-http/httplug-bundle": "To easier configure your httplug clients.",
-        "happyr/auto-fallback-translation-bundle": "To automatically translate phrases that are missing form your secondary language."
+        "happyr/auto-fallback-translation-bundle": "To automatically translate phrases that are missing form your secondary language.",
+        "php-http/guzzle6-adapter": "To enable Guzzl6HttpFactory and use this Http Adapter directly over configuration"
     },
     "autoload": {
         "psr-4": {

--- a/src/Http/Factory/FactoryInterface.php
+++ b/src/Http/Factory/FactoryInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Happyr\TranslationBundle\Http\Factory;
+
+use Http\Client\HttpClient;
+use Http\Message\MessageFactory;
+
+interface FactoryInterface
+{
+    /**
+     * @return HttpClient
+     */
+    public function createClient();
+
+    /**
+     * @return MessageFactory
+     */
+    public function createMessageFactory();
+}

--- a/src/Http/Factory/Guzzle6HttpFactory.php
+++ b/src/Http/Factory/Guzzle6HttpFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Happyr\TranslationBundle\Http\Factory;
+
+use GuzzleHttp\ClientInterface;
+use Http\Adapter\Guzzle6\Client;
+use Http\Message\MessageFactory\GuzzleMessageFactory;
+
+class Guzzle6HttpFactory implements FactoryInterface
+{
+    /**
+     * Guzzle6HttpFactory constructor.
+     */
+    public function __construct()
+    {
+        if (
+            !class_exists(Client::class) ||
+            !class_exists(GuzzleMessageFactory::class)
+        ) {
+            throw new \Exception("Guzzle6 not available - download with 'composer require php-http/guzzle6-adapter'");
+        }
+    }
+
+
+    /**
+     * @return ClientInterface
+     * @throws \Exception
+     */
+    public function createClient()
+    {
+        return new Client();
+    }
+
+    /**
+     * @return GuzzleMessageFactory
+     */
+    public function createMessageFactory()
+    {
+        return new GuzzleMessageFactory();
+    }
+}

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -40,3 +40,11 @@ services:
     class: Happyr\TranslationBundle\Http\RequestManager
     arguments: [~, ~]
     public: false
+
+  happyr.translation.http.guzzle6.client:
+    class: Http\Adapter\Guzzle6\Client
+    factory: [Happyr\TranslationBundle\Http\Factory\Guzzle6HttpFactory, createClient]
+
+  happyr.translation.http.guzzle6.message_factory:
+    class: Http\Adapter\Guzzle6\Client
+    factory: [Happyr\TranslationBundle\Http\Factory\Guzzle6HttpFactory, createMessageFactory]


### PR DESCRIPTION
Provide a simple Factory for direct usage of Guzzle6 as Http Client over configuration:
```
happyr_translation:
  httplug_client: happyr.translation.http.guzzle6.client
  httplug_message_factory: happyr.translation.http.guzzle6.message_factory
```