### PR TITLE
Loco tags management

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -61,6 +61,11 @@ class Configuration implements ConfigurationInterface
                     ->requiresAtLeastOneElement()
                     ->prototype('scalar')->end()
                 ->end()
+                ->arrayNode('tags')
+                    ->prototype('array')
+                        ->prototype('scalar')->end()
+                    ->end()
+                ->end()
             ->end()
         ->end();
 

--- a/src/Service/Loco.php
+++ b/src/Service/Loco.php
@@ -430,6 +430,16 @@ class Loco implements TranslationServiceInterface
 
             $data[$url] = $fileName;
         }
+
+        foreach ($config['tags'] as $locale => $tags) {
+            $query = $this->getExportQueryParams($config['api_key'], $tags);
+
+            // Build url
+            $url = sprintf('%sexport/locale/%s.%s?%s', self::BASE_URL, $locale, $this->filesystemService->getFileExtension(), http_build_query($query));
+            $fileName = sprintf('%s.%s.%s', $domain.'-'.(implode($tags, '-')), $locale, $this->filesystemService->getFileExtension());
+
+            $data[$url] = $fileName;
+        }
     }
 
     /**
@@ -437,13 +447,18 @@ class Loco implements TranslationServiceInterface
      *
      * @return array
      */
-    private function getExportQueryParams($key)
+    private function getExportQueryParams($key, $tags=null)
     {
         $data = array(
             'index' => 'id',
             'status' => 'translated',
             'key' => $key,
         );
+
+        if ($tags !== null) {
+            $data['filter'] = implode($tags, ',');
+        }
+
         switch ($this->filesystemService->getFileExtension()) {
             case 'php':
                 $data['format'] = 'zend'; // 'Zend' will give us a flat array


### PR DESCRIPTION
With this patch, you can specify tags for loco, and it will get the associated translation filtered by this tags.

    The generated translation filename is like 'domain-tag-tag...'
    Add this in your happyr_translation.yml config file :
    project:
        domain:
                tags:
                        [LOCALE]:
                                - '[TAG1]'
                                - '[TAG2]'