### PR TITLE
Loco filter parameters with GET method

### DIFF
--- a/src/Service/Loco.php
+++ b/src/Service/Loco.php
@@ -357,7 +357,7 @@ class Loco implements TranslationServiceInterface
 
         foreach ($config['locales'] as $locale) {
             $resource = sprintf('export/locale/%s.%s', $locale, 'json');
-            $response = $this->makeApiRequest($config['api_key'], 'GET', $resource, ['query' => $query]);
+            $response = $this->makeApiRequest($config['api_key'], 'GET', $resource, [], 'form', $query);
 
             $this->flatten($response);
 


### PR DESCRIPTION
I faced with a bug, when I ran a happyr:translationbundle:sync in my symfony project, all translations appeared in all domain files, this completely mixed up my project. According to [loco API documentation](https://localise.biz/api/docs/export/exportlocale) about locale export endpoint, it accepts get parameters. This fix worked for me.