### PR TITLE
[FIX] Symfony vardumper passes objects instead of array typehint

### DIFF
--- a/src/Model/Message.php
+++ b/src/Model/Message.php
@@ -73,7 +73,7 @@ class Message
      * @param array $data
      *                    array( count = 1, domain = "navigation", id = "logout", locale = "sv", state = 1, translation = "logout" )
      */
-    public function __construct(array $data)
+    public function __construct($data)
     {
         $this->domain = $data['domain'];
         $this->id = $data['id'];


### PR DESCRIPTION
Symfony Vardumper component is used in the translation datacollector.
This produces messages of type "Stub" or "Data", passing them to the constructor of the Message model which expects an array will throw fatal exception.

Error was discovered using Sylius 1.0-beta2 using Symfony 3.3.

Relevant lines:
vendor/happyr/translation-bundle/src/Controller/ProfilerController.php:185

Origin of error:

Profiler->flag message -> vendor/happyr/translation-bundle/src/Controller/ProfilerController.php:71