### PR TITLE
Fix query parameters for synchronize command

### DIFF
--- a/src/Service/Loco.php
+++ b/src/Service/Loco.php
@@ -357,7 +357,7 @@ class Loco implements TranslationServiceInterface
 
         foreach ($config['locales'] as $locale) {
             $resource = sprintf('export/locale/%s.%s', $locale, 'json');
-            $response = $this->makeApiRequest($config['api_key'], 'GET', $resource, ['query' => $query]);
+            $response = $this->makeApiRequest($config['api_key'], 'GET', $resource, null, null, $query);
 
             $this->flatten($response);
 


### PR DESCRIPTION
Actually the filters get not passed to the query string for the request. Ending up with all translations in all domains/files.